### PR TITLE
added flag for zipping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,5 @@ setuptools.setup(
         'numpy',
         'sympy',
     ],
+    zip_safe=True,
 )


### PR DESCRIPTION
When installing a warning comes up in red I think that this can be fixed by adding a little flag to the setup.py. This will slightly speed up the install as it won't have to check for zip compatibility

![warning](https://user-images.githubusercontent.com/8583900/92393049-24abc480-f117-11ea-8590-9eac9f151a6e.png)
