### PR TITLE
Fix CI: drop EOL Python 3.7, test on 3.9-3.12

### DIFF
--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -18,14 +18,15 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
-      - uses: actions/checkout@v2
-      
+      - uses: actions/checkout@v4
+
       - name: Set up Python ${{matrix.python-version}}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
       - name: install package


### PR DESCRIPTION
CI has been failing because the `testing (3.7)` job can't set up Python 3.7 anymore (`Version 3.7 with arch x64 not found`) — 3.7 is end-of-life and no longer shipped on the GitHub Actions runners. With the default fail-fast strategy that also cancelled the 3.8 and 3.9 jobs, so every run went red.

Changes:
- Test on Python 3.9, 3.10, 3.11 and 3.12 (drop the EOL 3.7/3.8)
- Bump `actions/checkout` to v4 and `actions/setup-python` to v5 (the v2 versions run on the deprecated Node 20)
- Set `fail-fast: false` so one version failing no longer hides the others

Tests pass locally on 3.13 with matplotlib 3.11.